### PR TITLE
Add multilingual UI support with language selector

### DIFF
--- a/data/beer_styles.json
+++ b/data/beer_styles.json
@@ -1,7 +1,8 @@
 {
-  "Leichtes Ale": {
+  "light_ale": {
+    "names": {"de": "Leichtes Ale", "en": "Light Ale"},
     "base": [0.0, 0.0, 0.0, 0.0],
-    "min_counts": {"Helles Malz": 1, "Standardhefe": 1},
+    "min_counts": {"pale_malt": 1, "standard_yeast": 1},
     "bands": {
       "taste": [
         {"band": "red", "min": 0.0, "max": 0.99},
@@ -28,9 +29,10 @@
       ]
     }
   },
-  "Blonde Ale": {
+  "blonde_ale": {
+    "names": {"de": "Blonde Ale", "en": "Blonde Ale"},
     "base": [0.0, 0.0, 0.0, 0.0],
-    "min_counts": {"Grut": 1, "Helles Malz": 1, "Standardhefe": 1},
+    "min_counts": {"grut": 1, "pale_malt": 1, "standard_yeast": 1},
     "bands": {
       "taste": [
         {"band": "red", "min": 0.0, "max": 0.99},
@@ -59,9 +61,10 @@
       ]
     }
   },
-  "Old Ale": {
+  "old_ale": {
+    "names": {"de": "Old Ale", "en": "Old Ale"},
     "base": [0.0, 0.0, 0.0, 0.0],
-    "min_counts": {"Grut": 1, "Braunes Malz": 1, "Helles Malz": 1, "Standardhefe": 1},
+    "min_counts": {"grut": 1, "brown_malt": 1, "pale_malt": 1, "standard_yeast": 1},
     "bands": {
       "taste": [
         {"band": "red", "min": 0.0, "max": 1.99},
@@ -91,9 +94,17 @@
       ]
     }
   },
-  "Kräuterbier": {
+  "herbal_beer": {
+    "names": {"de": "Kräuterbier", "en": "Herbal Beer"},
     "base": [0.0, 0.0, 0.0, 0.0],
-    "min_counts": {"Eukalyptus": 1, "Grut": 1, "Honig": 1, "Bernsteinfarbenes Malz": 1, "Helles Malz": 1, "Standardhefe": 1},
+    "min_counts": {
+      "eucalyptus": 1,
+      "grut": 1,
+      "honey": 1,
+      "amber_malt": 1,
+      "pale_malt": 1,
+      "standard_yeast": 1
+    },
     "bands": {
       "taste": [
         {"band": "red", "min": 0.0, "max": 3.99},

--- a/data/ingredients.json
+++ b/data/ingredients.json
@@ -1,9 +1,37 @@
 [
-  {"name": "Standardhefe", "vec": [0.5, 0.0, -1.0, -0.5]},
-  {"name": "Helles Malz", "vec": [0.4, 0.3, 1.0, 0.5]},
-  {"name": "Grut", "vec": [0.5, -0.3, 0.0, 0.0]},
-  {"name": "Braunes Malz", "vec": [1.6, 2.0, 0.0, 0.0]},
-  {"name": "Eukalyptus", "vec": [1.0, 0.0, -0.2, -0.5]},
-  {"name": "Bernsteinfarbenes Malz", "vec": [0.8, 1.2, 0.5, 0.8]},
-  {"name": "Honig", "vec": [1.0, 0.3, 1.0, 0.0]}
+  {
+    "id": "standard_yeast",
+    "names": {"de": "Standardhefe", "en": "Standard Yeast"},
+    "vec": [0.5, 0.0, -1.0, -0.5]
+  },
+  {
+    "id": "pale_malt",
+    "names": {"de": "Helles Malz", "en": "Pale Malt"},
+    "vec": [0.4, 0.3, 1.0, 0.5]
+  },
+  {
+    "id": "grut",
+    "names": {"de": "Grut", "en": "Gruit"},
+    "vec": [0.5, -0.3, 0.0, 0.0]
+  },
+  {
+    "id": "brown_malt",
+    "names": {"de": "Braunes Malz", "en": "Brown Malt"},
+    "vec": [1.6, 2.0, 0.0, 0.0]
+  },
+  {
+    "id": "eucalyptus",
+    "names": {"de": "Eukalyptus", "en": "Eucalyptus"},
+    "vec": [1.0, 0.0, -0.2, -0.5]
+  },
+  {
+    "id": "amber_malt",
+    "names": {"de": "Bernsteinfarbenes Malz", "en": "Amber Malt"},
+    "vec": [0.8, 1.2, 0.5, 0.8]
+  },
+  {
+    "id": "honey",
+    "names": {"de": "Honig", "en": "Honey"},
+    "vec": [1.0, 0.3, 1.0, 0.0]
+  }
 ]

--- a/data/translations.json
+++ b/data/translations.json
@@ -1,0 +1,142 @@
+{
+  "de": {
+    "language_name": "Deutsch",
+    "ui": {
+      "page_title": "Ale Abbey – Rezept-Solver",
+      "header_title": "🍺 Ale Abbey – Rezept-Solver",
+      "header_description": "Wähle für jede Eigenschaft die gewünschte Farbzone und lege exakte Wertebereiche fest. Die Berechnung berücksichtigt Pflichtzutaten, Mengenlimits und optionale Wünsche.",
+      "language_label": "Sprache",
+      "section_base": "Grunddaten",
+      "field_style": "Bierstil",
+      "field_total_cap": "Gesamtanzahl Zutaten (Cap)",
+      "field_per_cap": "Max pro Zutat",
+      "section_attributes": "Attribute",
+      "button_all_green": "Alle Attribute auf Grün",
+      "label_mode": "Modus",
+      "label_min": "Untergrenze",
+      "label_max": "Obergrenze",
+      "section_ingredients": "Zutatenübersicht",
+      "table_name": "Name",
+      "table_taste": "Geschmack",
+      "table_color": "Farbe",
+      "table_strength": "Stärke",
+      "table_foam": "Schaum",
+      "badge_required_single": "Pflicht",
+      "badge_required_multiple": "Pflicht × {count}",
+      "tooltip_required": "Diese Zutat ist vorgegeben.",
+      "button_submit": "Rezept berechnen",
+      "section_results": "Ergebnisse",
+      "results_empty": "Keine Lösung unter den gegebenen Regeln gefunden.",
+      "language_submit": "Sprache ändern"
+    },
+    "attr_labels": {
+      "taste": "Geschmack",
+      "color": "Farbe",
+      "strength": "Stärke",
+      "foam": "Schaum"
+    },
+    "band_labels": {
+      "any": "Egal",
+      "green": "Grün",
+      "yellow": "Gelb",
+      "red": "Rot",
+      "n/a": "Keine Angabe"
+    },
+    "modes": {
+      "any": "Egal",
+      "ge": "Mindestens",
+      "le": "Höchstens",
+      "between": "Zwischen"
+    },
+    "messages": {
+      "parse_error": "Konnte {id} nicht parsen",
+      "unknown_style": "Unbekannter Stil: {style}",
+      "min_exceeds_cap": "Pflichtanzahl übersteigt das Zutatencap.",
+      "no_intervals": "Keine passenden Intervalle für die gewählten Bänder.",
+      "cap_too_small": "Gesamtcap ist kleiner als die Summe der Pflichtzutaten.",
+      "results_title": "Ergebnisse ({count})",
+      "results_heading": "Ergebnisse",
+      "results_mix_title": "Zutatenmix",
+      "solutions_total": "Gesamtzutaten: {count}",
+      "raw_vector_title": "Roh-Vektor",
+      "summary_style": "Stil: {style}",
+      "summary_caps": "Cap gesamt {total}, pro Zutat {per}",
+      "debug_style": "Stil: {style}",
+      "debug_caps": "Gesamt-Cap: {total}, Pro-Zutat-Cap: {per}",
+      "debug_attr_heading": "Einstellungen je Attribut:",
+      "debug_attr_entry": "  {label} → Band: {band}, Intervall: [{min}, {max}]",
+      "debug_optional": "Zusätzliche gewünschte Zutaten: {list}",
+      "style_unknown": "—"
+    }
+  },
+  "en": {
+    "language_name": "English",
+    "ui": {
+      "page_title": "Ale Abbey – Recipe Solver",
+      "header_title": "🍺 Ale Abbey – Recipe Solver",
+      "header_description": "Choose the desired band for each attribute and define the value ranges. The solver respects required ingredients, quantity caps and optional wishes.",
+      "language_label": "Language",
+      "section_base": "Basics",
+      "field_style": "Beer style",
+      "field_total_cap": "Total ingredients (cap)",
+      "field_per_cap": "Max per ingredient",
+      "section_attributes": "Attributes",
+      "button_all_green": "Set all attributes to green",
+      "label_mode": "Mode",
+      "label_min": "Lower bound",
+      "label_max": "Upper bound",
+      "section_ingredients": "Ingredient overview",
+      "table_name": "Name",
+      "table_taste": "Taste",
+      "table_color": "Color",
+      "table_strength": "Strength",
+      "table_foam": "Foam",
+      "badge_required_single": "Required",
+      "badge_required_multiple": "Required × {count}",
+      "tooltip_required": "This ingredient is mandatory.",
+      "button_submit": "Calculate recipe",
+      "section_results": "Results",
+      "results_empty": "No solution found for the current constraints.",
+      "language_submit": "Change language"
+    },
+    "attr_labels": {
+      "taste": "Taste",
+      "color": "Color",
+      "strength": "Strength",
+      "foam": "Foam"
+    },
+    "band_labels": {
+      "any": "Any",
+      "green": "Green",
+      "yellow": "Yellow",
+      "red": "Red",
+      "n/a": "N/A"
+    },
+    "modes": {
+      "any": "Any",
+      "ge": "At least",
+      "le": "At most",
+      "between": "Between"
+    },
+    "messages": {
+      "parse_error": "Failed to parse {id}",
+      "unknown_style": "Unknown style: {style}",
+      "min_exceeds_cap": "Required amount exceeds the per-ingredient cap.",
+      "no_intervals": "No matching intervals for the selected bands.",
+      "cap_too_small": "Total cap is smaller than the sum of required ingredients.",
+      "results_title": "Results ({count})",
+      "results_heading": "Results",
+      "results_mix_title": "Ingredient mix",
+      "solutions_total": "Total ingredients: {count}",
+      "raw_vector_title": "Raw vector",
+      "summary_style": "Style: {style}",
+      "summary_caps": "Cap total {total}, per ingredient {per}",
+      "debug_style": "Style: {style}",
+      "debug_caps": "Total cap: {total}, per ingredient cap: {per}",
+      "debug_attr_heading": "Attribute settings:",
+      "debug_attr_entry": "  {label} → Band: {band}, Range: [{min}, {max}]",
+      "debug_optional": "Additional desired ingredients: {list}",
+      "style_unknown": "—"
+    }
+  }
+}

--- a/static/styles.css
+++ b/static/styles.css
@@ -34,6 +34,13 @@ header {
   gap: 6px;
   margin-bottom: 28px;
 }
+header .header-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
 header h1 {
   font-size: clamp(2rem, 3vw, 2.6rem);
   margin: 0;
@@ -77,6 +84,24 @@ label span.label {
   color: var(--text-muted);
   font-weight: 600;
 }
+.language-switcher {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+}
+.language-switcher label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  font-weight: 600;
+}
+.language-switcher-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
 select,
 input[type="number"] {
   width: 100%;
@@ -86,6 +111,10 @@ input[type="number"] {
   font-size: 0.95rem;
   background: white;
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+.language-switcher select {
+  width: auto;
+  min-width: 150px;
 }
 select:focus,
 input[type="number"]:focus {

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,36 +1,53 @@
 <!doctype html>
-<html lang="de">
+<html lang="{{ lang }}">
 <head>
   <meta charset="utf-8">
-  <title>Ale Abbey Rezept-Solver</title>
+  <title>{{ ui.page_title }}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
 </head>
 <body>
   <div class="page">
     <header>
-      <h1>🍺 Ale Abbey – Rezept-Solver</h1>
-      <p>Wähle für jede Eigenschaft die gewünschte Farbzone und lege exakte Wertebereiche fest. Die Berechnung berücksichtigt Pflichtzutaten, Mengenlimits und optionale Wünsche.</p>
+      <div class="header-row">
+        <h1>{{ ui.header_title }}</h1>
+        <form class="language-switcher" method="get">
+          <label for="language-select">{{ ui.language_label }}</label>
+          <div class="language-switcher-controls">
+            <select id="language-select" name="lang" onchange="this.form.submit()">
+              {% for entry in languages %}
+                <option value="{{ entry.code }}" {% if entry.code == lang %}selected{% endif %}>{{ entry.label }}</option>
+              {% endfor %}
+            </select>
+            <noscript>
+              <button type="submit" class="btn-secondary">{{ ui.language_submit }}</button>
+            </noscript>
+          </div>
+          <input type="hidden" name="style" value="{{ style }}">
+        </form>
+      </div>
+      <p>{{ ui.header_description }}</p>
     </header>
 
     <form class="card form-card" data-solver-form>
+      <input type="hidden" name="lang" value="{{ lang }}">
       <section>
-        <h3 class="section-title">Grunddaten</h3>
+        <h3 class="section-title">{{ ui.section_base }}</h3>
         <div class="grid-two">
           <label>
-            <span class="label">Bierstil</span>
+            <span class="label">{{ ui.field_style }}</span>
             <select name="style">
               {% for s in styles %}
-                <option value="{{ s }}" {% if s == style %}selected{% endif %}>{{ s }}</option>
+                <option value="{{ s.id }}" {% if s.id == style %}selected{% endif %}>{{ s.name }}</option>
               {% endfor %}
             </select>
           </label>
           <label>
-            <span class="label">Gesamtanzahl Zutaten (Cap)</span>
+            <span class="label">{{ ui.field_total_cap }}</span>
             <input type="number" name="total_cap" min="1" max="30" value="{{ total_cap }}">
           </label>
           <label>
-            <span class="label">Max pro Zutat</span>
+            <span class="label">{{ ui.field_per_cap }}</span>
             <input type="number" name="per_cap" min="1" max="30" value="{{ per_cap }}">
           </label>
         </div>
@@ -38,8 +55,8 @@
 
       <section>
         <div class="section-header">
-          <h3 class="section-title">Attribute</h3>
-          <button type="button" class="btn-secondary" data-set-all-green>Alle Attribute auf Grün</button>
+          <h3 class="section-title">{{ ui.section_attributes }}</h3>
+          <button type="button" class="btn-secondary" data-set-all-green>{{ ui.button_all_green }}</button>
         </div>
         <div class="attr-grid">
           {% for a in attrs %}
@@ -56,18 +73,18 @@
               </div>
 
               <div>
-                <label class="label" style="margin-top:12px;">Modus</label>
+                <label class="label" style="margin-top:12px;">{{ ui.label_mode }}</label>
                 <select class="mode-select" name="mode_{{ a }}">
-                  <option value="any" {% if constraints[a].mode == 'any' %}selected{% endif %}>Egal</option>
-                  <option value="ge" {% if constraints[a].mode == 'ge' %}selected{% endif %}>Mindestens</option>
-                  <option value="le" {% if constraints[a].mode == 'le' %}selected{% endif %}>Höchstens</option>
-                  <option value="between" {% if constraints[a].mode == 'between' %}selected{% endif %}>Zwischen</option>
+                  <option value="any" {% if constraints[a].mode == 'any' %}selected{% endif %}>{{ mode_labels['any'] }}</option>
+                  <option value="ge" {% if constraints[a].mode == 'ge' %}selected{% endif %}>{{ mode_labels['ge'] }}</option>
+                  <option value="le" {% if constraints[a].mode == 'le' %}selected{% endif %}>{{ mode_labels['le'] }}</option>
+                  <option value="between" {% if constraints[a].mode == 'between' %}selected{% endif %}>{{ mode_labels['between'] }}</option>
                 </select>
                 <div class="range-inputs">
-                  <label>Untergrenze
+                  <label>{{ ui.label_min }}
                     <input type="number" class="min-input" name="min_{{ a }}" step="0.1" min="0" max="11" value="{{ constraints[a].min }}">
                   </label>
-                  <label>Obergrenze
+                  <label>{{ ui.label_max }}
                     <input type="number" class="max-input" name="max_{{ a }}" step="0.1" min="0" max="11" value="{{ constraints[a].max }}">
                   </label>
                 </div>
@@ -80,30 +97,30 @@
       <section>
         <details class="collapsible" data-collapsible open>
           <summary>
-            <h3 class="section-title">Zutatenübersicht</h3>
+            <h3 class="section-title">{{ ui.section_ingredients }}</h3>
           </summary>
           <div class="table-wrapper">
             <table class="ingredients-table">
               <thead>
                 <tr>
                   <th class="col-checkbox"></th>
-                  <th>Name</th>
-                  <th>Geschmack</th>
-                  <th>Farbe</th>
-                  <th>Stärke</th>
-                  <th>Schaum</th>
+                  <th>{{ ui.table_name }}</th>
+                  <th>{{ ui.table_taste }}</th>
+                  <th>{{ ui.table_color }}</th>
+                  <th>{{ ui.table_strength }}</th>
+                  <th>{{ ui.table_foam }}</th>
                 </tr>
               </thead>
               <tbody>
                 {% for ing in ingredients %}
-                  {% set required_count = style_mins.get(ing.name, 0) %}
+                  {% set required_count = style_mins.get(ing.id, 0) %}
                   {% set is_required = required_count > 0 %}
                   {% set is_locked = is_required %}
-                  {% set is_checked = is_locked or ing.name in selected_optional %}
-                  <tr class="{% if is_locked %}ingredient-locked{% endif %}" data-ingredient-row data-ingredient-name="{{ ing.name }}">
+                  {% set is_checked = is_locked or ing.id in selected_optional %}
+                  <tr class="{% if is_locked %}ingredient-locked{% endif %}" data-ingredient-row data-ingredient-id="{{ ing.id }}">
                     <td class="checkbox-cell">
-                      <label class="ingredient-option" {% if is_locked %}title="Diese Zutat ist vorgegeben."{% endif %}>
-                        <input type="checkbox" name="optional_ingredients" value="{{ ing.name }}" {% if is_checked %}checked{% endif %} {% if is_locked %}disabled{% endif %} data-user-selected="{{ 'true' if ing.name in selected_optional else 'false' }}">
+                      <label class="ingredient-option" {% if is_locked %}title="{{ ui.tooltip_required }}"{% endif %}>
+                        <input type="checkbox" name="optional_ingredients" value="{{ ing.id }}" {% if is_checked %}checked{% endif %} {% if is_locked %}disabled{% endif %} data-user-selected="{{ 'true' if ing.id in selected_optional else 'false' }}">
                         <span class="checkbox-visual"></span>
                       </label>
                     </td>
@@ -112,9 +129,13 @@
                         <span>{{ ing.name }}</span>
                         <span class="ingredient-badge badge-required" data-required-badge {% if not is_required %}hidden{% endif %}>
                           {% if is_required %}
-                            Pflicht{% if required_count > 1 %} × {{ required_count }}{% endif %}
+                            {% if required_count > 1 %}
+                              {{ ui.badge_required_multiple | replace('{count}', '%d' % required_count) }}
+                            {% else %}
+                              {{ ui.badge_required_single }}
+                            {% endif %}
                           {% else %}
-                            Pflicht
+                            {{ ui.badge_required_single }}
                           {% endif %}
                         </span>
                       </div>
@@ -131,21 +152,22 @@
         </details>
       </section>
 
-      <button class="btn-primary" type="submit" data-submit-button {% if not has_active_constraints %}disabled{% endif %}>Rezept berechnen</button>
+      <button class="btn-primary" type="submit" data-submit-button {% if not has_active_constraints %}disabled{% endif %}>{{ ui.button_submit }}</button>
     </form>
 
     <section class="results-section" data-results hidden style="margin-top: 32px;">
-      <h2 class="section-title" data-results-title>Ergebnisse</h2>
+      <h2 class="section-title" data-results-title>{{ ui.section_results }}</h2>
       <p class="hint" data-results-summary></p>
       <p class="hint" data-status-message hidden></p>
-      <p data-results-empty hidden><strong>Keine Lösung</strong> unter den gegebenen Regeln gefunden.</p>
+      <p data-results-empty hidden><strong>{{ ui.section_results }}</strong> {{ ui.results_empty }}</p>
       <div class="grid-two" data-results-list></div>
     </section>
   </div>
 
   <script id="ingredients-data" type="application/json">{{ ingredients_data | tojson }}</script>
   <script id="styles-data" type="application/json">{{ styles_data | tojson }}</script>
-  <script id="meta-data" type="application/json">{{ {'attrs': attrs, 'attr_labels': attr_labels, 'band_labels': band_labels} | tojson }}</script>
+  <script id="meta-data" type="application/json">{{ meta_data | tojson }}</script>
+  <script id="i18n-data" type="application/json">{{ i18n_payload | tojson }}</script>
   <script id="style-min-data" type="application/json">{{ style_min_map | tojson }}</script>
   <script type="module" src="{{ url_for('static', filename='solver.js') }}"></script>
 </body>


### PR DESCRIPTION
## Summary
- load translation resources on the server and expose localized ingredient/style metadata with the active language
- update the template, styles, and solver script to render UI text from translations and allow runtime language switching

## Testing
- python -m py_compile app.py

------
https://chatgpt.com/codex/tasks/task_e_68e244847aa48329bac99a29aa635ce4