### PR TITLE
Fix ingredient table mobile layout

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -1363,9 +1363,15 @@ details summary {
   }
 
   .ingredient-name {
-    align-items: flex-start;
-    flex-direction: column;
-    gap: 6px;
+    align-items: center;
+    flex-direction: row;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+
+  .ingredients-table td.ingredient-name-cell::before {
+    display: none;
+    content: none;
   }
 
   .ingredient-option {

--- a/templates/index.html
+++ b/templates/index.html
@@ -181,7 +181,7 @@
                                                     <span class="checkbox-visual"></span>
                                                 </label>
                                             </td>
-                                            <td data-label="{{ ui.table_name }}">
+                                            <td class="ingredient-name-cell" data-label="{{ ui.table_name }}">
                                                 <div class="ingredient-name">
                                                     <span>{{ ing.name }}</span>
                                                     <span class="ingredient-badge badge-required" data-required-badge


### PR DESCRIPTION
## Summary
- hide the duplicated "Name" label for ingredient rows on narrow screens
- keep the required badge inline so locked ingredients stay the same height as optional ones

## Testing
- Manual verification in a 375px-wide viewport

------
https://chatgpt.com/codex/tasks/task_e_68e77f3e6bf48329ba2bdc2b57915320