### PR TITLE
Clamp negative attribute totals in result UI

### DIFF
--- a/static/solver.js
+++ b/static/solver.js
@@ -1139,7 +1139,8 @@ const initSolver = () => {
     if (!Number.isFinite(value)) {
       return '0';
     }
-    const rounded = Math.round(value * 10) / 10;
+    const safeValue = Math.max(0, value);
+    const rounded = Math.round(safeValue * 10) / 10;
     if (Math.abs(rounded - Math.round(rounded)) < 1e-6) {
       return String(Math.round(rounded));
     }
@@ -1338,7 +1339,8 @@ const initSolver = () => {
       );
 
       ATTRS.forEach((attr, idx) => {
-        const value = Number(solution.totals[idx]) || 0;
+        const rawValue = Number(solution.totals[idx]);
+        const value = Number.isFinite(rawValue) ? Math.max(0, rawValue) : 0;
         const band = solution.bands[attr];
         const sanitized = sanitizeBand(band);
 


### PR DESCRIPTION
## Summary
- clamp formatted result values at zero so negative totals display as 0
- ensure attribute chart bars use non-negative totals for height and labels

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7e40f68d883298e5b7ca74953809b