### PR TITLE
Hide ingredient cap inputs from calculator UI

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -44,15 +44,9 @@
                         {% endfor %}
                     </select>
                 </label>
-                <label>
-                    <span class="label">{{ ui.field_total_cap }}</span>
-                    <input type="number" name="total_cap" min="1" max="30" value="{{ total_cap }}">
-                </label>
-                <label>
-                    <span class="label">{{ ui.field_per_cap }}</span>
-                    <input type="number" name="per_cap" min="1" max="30" value="{{ per_cap }}">
-                </label>
             </div>
+            <input type="hidden" name="total_cap" value="{{ total_cap }}">
+            <input type="hidden" name="per_cap" value="{{ per_cap }}">
         </section>
 
         <section class="attributes-section">


### PR DESCRIPTION
## Summary
- remove the visible total and per ingredient cap inputs from the solver form so the fixed values are no longer user-editable
- keep the fixed cap values submitted via hidden inputs to preserve solver behaviour

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e802e5cda08329914a766e9d09bdb7