### PR TITLE
Refactor result rendering helpers

### DIFF
--- a/static/render.js
+++ b/static/render.js
@@ -1,16 +1,170 @@
-const clearChildren = (node) => {
-  if (!node) return;
-  while (node.firstChild) {
-    node.removeChild(node.firstChild);
-  }
+let cachedContext = null;
+
+const createBandPill = (attr, band, dictionaries = {}) => {
+  const {
+    sanitizeBand = (value) => value,
+    attrLabels = {},
+    bandLabels = {},
+  } = dictionaries;
+
+  const sanitized = sanitizeBand(band);
+  const pill = document.createElement('span');
+  pill.className = `pill ${sanitized}`;
+
+  const label = attrLabels[attr] || attr;
+  const bandLabel = bandLabels[band] || band || 'n/a';
+  pill.textContent = `${label}: ${bandLabel}`;
+
+  return pill;
 };
 
-let cachedContext = null;
+const createAttributeBar = (attr, value, band, scaleMax, dictionaries = {}) => {
+  const {
+    attrLabels = {},
+    bandLabels = {},
+    formatResultValue = (val) => String(val),
+    sanitizeBand = (val) => val,
+    clamp = (val) => val,
+  } = dictionaries;
+
+  const label = attrLabels[attr] || attr;
+  const bandLabel = bandLabels[band] || band || 'n/a';
+  const sanitized = sanitizeBand(band);
+
+  const bar = document.createElement('div');
+  bar.className = 'result-attr-bar';
+  bar.setAttribute('role', 'group');
+  bar.setAttribute(
+    'aria-label',
+    `${label}: ${formatResultValue(value)} (${bandLabel})`,
+  );
+
+  const valueLabel = document.createElement('span');
+  valueLabel.className = 'result-attr-value';
+  valueLabel.textContent = formatResultValue(value);
+  bar.appendChild(valueLabel);
+
+  const track = document.createElement('div');
+  track.className = 'result-attr-track';
+
+  const fill = document.createElement('div');
+  fill.className = 'result-attr-fill';
+  fill.dataset.band = sanitized;
+
+  const percent = scaleMax > 0 ? clamp((value / scaleMax) * 100, 0, 100) : 0;
+  fill.style.height = `${percent}%`;
+  fill.title = `${label}: ${formatResultValue(value)}`;
+
+  track.appendChild(fill);
+  bar.appendChild(track);
+
+  const nameLabel = document.createElement('span');
+  nameLabel.className = 'result-attr-name';
+  nameLabel.textContent = label;
+  bar.appendChild(nameLabel);
+
+  return bar;
+};
+
+export const renderResultCard = (solution, dictionaries = {}) => {
+  const {
+    translate = (key) => key,
+    displayIngredientName = (value) => value,
+    ATTRS = [],
+  } = dictionaries;
+
+  const index = typeof dictionaries.index === 'number' ? dictionaries.index : 0;
+
+  const card = document.createElement('article');
+  card.className = 'card result-card';
+
+  const header = document.createElement('div');
+  header.className = 'result-card-header';
+
+  const titleRow = document.createElement('div');
+  titleRow.className = 'result-card-title-row';
+
+  const heading = document.createElement('h3');
+  const sum = Number.isFinite(solution && solution.sum) ? solution.sum : 0;
+  heading.textContent = translate('solutions_total', { count: sum });
+  titleRow.appendChild(heading);
+
+  const bandContainer = document.createElement('div');
+  bandContainer.className = 'result-band-pills result-band-pills--inline';
+  titleRow.appendChild(bandContainer);
+
+  header.appendChild(titleRow);
+
+  const rank = document.createElement('span');
+  rank.className = 'result-card-rank';
+  rank.textContent = `#${index + 1}`;
+  header.appendChild(rank);
+
+  card.appendChild(header);
+
+  const mixSection = document.createElement('div');
+  mixSection.className = 'result-ingredients';
+
+  const mixTitle = document.createElement('p');
+  mixTitle.className = 'result-section-title';
+  mixTitle.textContent = translate('results_mix_title');
+  mixSection.appendChild(mixTitle);
+
+  const chipsContainer = document.createElement('div');
+  chipsContainer.className = 'chips';
+  const countsById = solution && typeof solution.countsById === 'object'
+    ? solution.countsById
+    : {};
+  Object.entries(countsById).forEach(([id, cnt]) => {
+    const chip = document.createElement('span');
+    chip.className = 'chip';
+    const label = `${displayIngredientName(id)} × ${cnt}`;
+    chip.title = label;
+    const span = document.createElement('span');
+    span.textContent = label;
+    chip.appendChild(span);
+    chipsContainer.appendChild(chip);
+  });
+  mixSection.appendChild(chipsContainer);
+  card.appendChild(mixSection);
+
+  const attrTitle = document.createElement('p');
+  attrTitle.className = 'result-section-title';
+  attrTitle.textContent = translate('section_attributes');
+  card.appendChild(attrTitle);
+
+  const chart = document.createElement('div');
+  chart.className = 'result-attr-chart';
+
+  const totals = Array.isArray(solution && solution.totals) ? solution.totals : [];
+  const scaleMax = Math.max(
+    12,
+    ...totals.map((value) => (Number.isFinite(value) ? value : 0)),
+  );
+
+  ATTRS.forEach((attr, idx) => {
+    const rawValue = Number(totals[idx]);
+    const value = Number.isFinite(rawValue) ? Math.max(0, rawValue) : 0;
+    const band = solution && solution.bands ? solution.bands[attr] : null;
+    const bar = createAttributeBar(attr, value, band, scaleMax, dictionaries);
+    chart.appendChild(bar);
+  });
+
+  card.appendChild(chart);
+
+  ATTRS.forEach((attr) => {
+    const band = solution && solution.bands ? solution.bands[attr] : null;
+    const pill = createBandPill(attr, band, dictionaries);
+    bandContainer.appendChild(pill);
+  });
+
+  return card;
+};
 
 export const renderResults = (solutions, dictionaries) => {
   cachedContext = dictionaries ? { ...dictionaries } : cachedContext;
   if (!cachedContext) {
-    return;
+    return { cards: [] };
   }
 
   const {
@@ -35,14 +189,13 @@ export const renderResults = (solutions, dictionaries) => {
     resultsSummary,
     resultsPlaceholder,
     resultsLoading,
-    resultsList,
     resultsEmpty,
     statusMessage,
     resultsControls,
   } = selectors;
 
   if (!resultsSection) {
-    return;
+    return { cards: [] };
   }
 
   if (resultsLoading) {
@@ -59,8 +212,7 @@ export const renderResults = (solutions, dictionaries) => {
     if (statusMessage) statusMessage.hidden = true;
     if (resultsEmpty) resultsEmpty.hidden = true;
     if (resultsControls) resultsControls.hidden = true;
-    if (resultsList) clearChildren(resultsList);
-    return;
+    return { cards: [] };
   }
 
   if (!hasRenderedResults) {
@@ -75,8 +227,7 @@ export const renderResults = (solutions, dictionaries) => {
     }
     if (resultsEmpty) resultsEmpty.hidden = true;
     if (resultsControls) resultsControls.hidden = true;
-    if (resultsList) clearChildren(resultsList);
-    return;
+    return { cards: [] };
   }
 
   if (resultsPlaceholder) {
@@ -122,133 +273,16 @@ export const renderResults = (solutions, dictionaries) => {
     resultsControls.hidden = count === 0;
   }
 
-  if (resultsList) {
-    clearChildren(resultsList);
-  }
-
   if (count === 0) {
-    return;
+    return { cards: [] };
   }
 
-  list.forEach((solution, index) => {
-    const card = document.createElement('article');
-    card.className = 'card result-card';
+  const cards = list.map((solution, index) => renderResultCard(solution, {
+    ...cachedContext,
+    index,
+  }));
 
-    const header = document.createElement('div');
-    header.className = 'result-card-header';
-
-    const titleRow = document.createElement('div');
-    titleRow.className = 'result-card-title-row';
-
-    const heading = document.createElement('h3');
-    heading.textContent = translate('solutions_total', { count: solution.sum });
-    titleRow.appendChild(heading);
-
-    const bandContainer = document.createElement('div');
-    bandContainer.className = 'result-band-pills result-band-pills--inline';
-    titleRow.appendChild(bandContainer);
-
-    header.appendChild(titleRow);
-
-    const rank = document.createElement('span');
-    rank.className = 'result-card-rank';
-    rank.textContent = `#${index + 1}`;
-    header.appendChild(rank);
-
-    card.appendChild(header);
-
-    const mixSection = document.createElement('div');
-    mixSection.className = 'result-ingredients';
-
-    const mixTitle = document.createElement('p');
-    mixTitle.className = 'result-section-title';
-    mixTitle.textContent = translate('results_mix_title');
-    mixSection.appendChild(mixTitle);
-
-    const chipsContainer = document.createElement('div');
-    chipsContainer.className = 'chips';
-    Object.entries(solution.countsById).forEach(([id, cnt]) => {
-      const chip = document.createElement('span');
-      chip.className = 'chip';
-      const label = `${displayIngredientName(id)} × ${cnt}`;
-      chip.title = label;
-      const span = document.createElement('span');
-      span.textContent = label;
-      chip.appendChild(span);
-      chipsContainer.appendChild(chip);
-    });
-    mixSection.appendChild(chipsContainer);
-    card.appendChild(mixSection);
-
-    const attrTitle = document.createElement('p');
-    attrTitle.className = 'result-section-title';
-    attrTitle.textContent = translate('section_attributes');
-    card.appendChild(attrTitle);
-
-    const chart = document.createElement('div');
-    chart.className = 'result-attr-chart';
-
-    const scaleMax = Math.max(
-      12,
-      ...solution.totals.map((value) => (Number.isFinite(value) ? value : 0)),
-    );
-
-    ATTRS.forEach((attr, idx) => {
-      const rawValue = Number(solution.totals[idx]);
-      const value = Number.isFinite(rawValue) ? Math.max(0, rawValue) : 0;
-      const band = solution.bands[attr];
-      const sanitized = sanitizeBand(band);
-
-      const bar = document.createElement('div');
-      bar.className = 'result-attr-bar';
-      bar.setAttribute('role', 'group');
-      bar.setAttribute(
-        'aria-label',
-        `${attrLabels[attr] || attr}: ${formatResultValue(value)} (${bandLabels[band] || band || 'n/a'})`,
-      );
-
-      const valueLabel = document.createElement('span');
-      valueLabel.className = 'result-attr-value';
-      valueLabel.textContent = formatResultValue(value);
-      bar.appendChild(valueLabel);
-
-      const track = document.createElement('div');
-      track.className = 'result-attr-track';
-
-      const fill = document.createElement('div');
-      fill.className = 'result-attr-fill';
-      fill.dataset.band = sanitized;
-      const percent = scaleMax > 0 ? clamp((value / scaleMax) * 100, 0, 100) : 0;
-      fill.style.height = `${percent}%`;
-      fill.title = `${attrLabels[attr] || attr}: ${formatResultValue(value)}`;
-      track.appendChild(fill);
-      bar.appendChild(track);
-
-      const nameLabel = document.createElement('span');
-      nameLabel.className = 'result-attr-name';
-      nameLabel.textContent = attrLabels[attr] || attr;
-      bar.appendChild(nameLabel);
-
-      chart.appendChild(bar);
-    });
-
-    card.appendChild(chart);
-
-    ATTRS.forEach((attr) => {
-      const band = solution.bands[attr];
-      const sanitized = sanitizeBand(band);
-      const pill = document.createElement('span');
-      pill.className = `pill ${sanitized}`;
-      const label = attrLabels[attr] || attr;
-      const bandLabel = bandLabels[band] || band || 'n/a';
-      pill.textContent = `${label}: ${bandLabel}`;
-      bandContainer.appendChild(pill);
-    });
-
-    if (resultsList) {
-      resultsList.appendChild(card);
-    }
-  });
+  return { cards };
 };
 
 export const renderDebug = (lines) => {

--- a/static/solver.js
+++ b/static/solver.js
@@ -1430,7 +1430,7 @@ const initSolver = () => {
     const infoMessages = Array.isArray(latestInfoMessages) ? latestInfoMessages : [];
     const sortedSolutions = hasRenderedResults ? sortSolutionsForDisplay(latestSolutions) : [];
 
-    renderResults(sortedSolutions, {
+    const rendered = renderResults(sortedSolutions, {
       selectors,
       translate,
       attrLabels,
@@ -1445,6 +1445,20 @@ const initSolver = () => {
       isLoading,
       hasRenderedResults,
     });
+
+    const cards = rendered && Array.isArray(rendered.cards) ? rendered.cards : [];
+    if (resultsList) {
+      if (typeof resultsList.replaceChildren === 'function') {
+        resultsList.replaceChildren(...cards);
+      } else {
+        resultsList.innerHTML = '';
+        cards.forEach((card) => {
+          if (card && typeof card === 'object' && typeof card.nodeType === 'number') {
+            resultsList.appendChild(card);
+          }
+        });
+      }
+    }
   };
 
   applyResultsState();


### PR DESCRIPTION
## Summary
- extract a reusable `renderResultCard` helper and supporting builders for attribute bars and band pills
- make `renderResults` return rendered cards instead of mutating the list directly
- update `applyResultsState` to replace the result list contents with the rendered cards

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e9693384b083299edfe0a2dd49dfbc