### PR TITLE
Normalize ingredient data vectors

### DIFF
--- a/static/solver-core.js
+++ b/static/solver-core.js
@@ -3,7 +3,7 @@
  * @property {string} [id]
  * @property {string} [name]
  * @property {Record<string, string>} [names]
- * @property {string} [category_id]
+ * @property {string} [category]
  * @property {number[]} vec
  */
 

--- a/static/solver.js
+++ b/static/solver.js
@@ -58,7 +58,13 @@ const buildIngredientCaches = (list, ingredientNames, currentLang) => {
     const displayName = resolveIngredientDisplayName(ingredient, id, ingredientNames, currentLang);
     ingredientIdToDisplayNameMap.set(id, displayName);
 
-    const categoryId = ingredient && ingredient.category_id ? ingredient.category_id : 'uncategorized';
+    let categoryId = 'uncategorized';
+    if (ingredient && ingredient.category !== undefined && ingredient.category !== null) {
+      const normalized = String(ingredient.category).trim();
+      if (normalized.length) {
+        categoryId = normalized;
+      }
+    }
     if (!ingredientCategoryIdToElementsMap.has(categoryId)) {
       ingredientCategoryIdToElementsMap.set(categoryId, []);
     }
@@ -104,19 +110,7 @@ const initSolver = () => {
   const i18nData = parseJSONScript('i18n-data', {});
   const styleMinMap = parseJSONScript('style-min-data', {});
   const rawIngredientData = parseJSONScript('ingredients-data', []);
-  const ingredientCategories = Array.isArray(rawIngredientData.categories)
-    ? rawIngredientData.categories
-    : Array.isArray(rawIngredientData)
-      ? [{ id: 'uncategorized', names: {}, ingredients: rawIngredientData }]
-      : [];
-  const ingredients = ingredientCategories.flatMap((category) => {
-    const items = Array.isArray(category.ingredients) ? category.ingredients : [];
-    return items.map((item) => ({
-      ...item,
-      category_id: category.id || '',
-      category_names: category.names || {},
-    }));
-  });
+  const ingredients = Array.isArray(rawIngredientData) ? rawIngredientData : [];
   const stylesData = parseJSONScript('styles-data', {});
   const metaData = parseJSONScript('meta-data', {});
 


### PR DESCRIPTION
## Summary
- normalize ingredient payloads on the server with numeric vectors, canonical category ids, and sanitized localized names
- expose the canonical ingredient list to templates and i18n helpers with improved localization fallbacks
- update the client-side solver to consume the canonical ingredient array and refreshed ingredient typing

## Testing
- python -m py_compile app.py

------
https://chatgpt.com/codex/tasks/task_e_68ea0bda678c8329903d5062a26f5f93