### PR TITLE
Refactor solver helpers into shared core

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "ale-abbey-beer-calculator",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/tests/solver-core.test.js
+++ b/tests/solver-core.test.js
@@ -1,0 +1,53 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  computeWeightedOrder,
+  computeSuffixBounds,
+  DEFAULT_TOP_K,
+} from '../static/solver-core.js';
+
+test('computeWeightedOrder sorts indices by max absolute coefficient', () => {
+  const vectors = [
+    [0, 2, -1],
+    [0, 0, 0],
+    [5, 0, 0],
+    [-1, -1, -1],
+  ];
+  assert.deepStrictEqual(computeWeightedOrder(vectors), [2, 0, 3, 1]);
+});
+
+test('computeWeightedOrder handles invalid input gracefully', () => {
+  // @ts-ignore testing defensive branch
+  assert.deepStrictEqual(computeWeightedOrder(null), []);
+});
+
+test('computeSuffixBounds returns aggregated ranges for ordered vectors', () => {
+  const vectors = [
+    [1, -2],
+    [-3, 4],
+  ];
+  const minCounts = [1, 0];
+  const maxCounts = [3, 2];
+  const { suffixMinCounts, suffixLo, suffixHi } = computeSuffixBounds(
+    vectors,
+    minCounts,
+    maxCounts,
+    2,
+  );
+  assert.deepStrictEqual(suffixMinCounts, [1, 0, 0]);
+  assert.deepStrictEqual(suffixLo, [
+    [-5, -6],
+    [-6, 0],
+    [0, 0],
+  ]);
+  assert.deepStrictEqual(suffixHi, [
+    [3, 6],
+    [0, 8],
+    [0, 0],
+  ]);
+});
+
+test('DEFAULT_TOP_K exposes solver default value', () => {
+  assert.strictEqual(DEFAULT_TOP_K, 10);
+});


### PR DESCRIPTION
## Summary
- export a shared DEFAULT_TOP_K constant along with helper utilities for ingredient ordering and suffix bounds in the solver core
- update the browser solver to rely on the shared helpers instead of duplicating the logic
- add node-based unit tests for the new helpers and wire them into npm test

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ea0c4e0398832983fb29eb3fb06ab9