### PR TITLE
Improve layout of results cards

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -914,14 +914,18 @@ input[type="number"]:focus {
 }
 
 .results-list {
-  display: flex;
-  flex-direction: column;
+  display: grid;
   gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  justify-content: center;
+  align-items: stretch;
 }
 
 .result-card {
   display: grid;
   gap: 18px;
+  width: min(100%, 480px);
+  margin: 0 auto;
 }
 
 .result-card-header {


### PR DESCRIPTION
## Summary
- arrange result cards in a responsive grid so multiple cards sit side by side when space allows
- cap individual result card width to approximately 480px to match the requested 400-500px range

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ea6bfc5b6083299c20d993d46b2fd2