### PR TITLE
Adjust seasonal cost chart height

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -1032,7 +1032,7 @@ input[type="number"]:focus {
 
 .result-cost-chart-bar-wrapper {
   width: 100%;
-  min-height: 60px;
+  height: 140px;
   display: flex;
   align-items: flex-end;
   justify-content: center;
@@ -1067,6 +1067,10 @@ input[type="number"]:focus {
 
   .result-cost-chart-column {
     min-width: 40px;
+  }
+
+  .result-cost-chart-bar-wrapper {
+    height: 110px;
   }
 }
 


### PR DESCRIPTION
## Summary
- increase the seasonal cost chart bar height to better use vertical space
- adjust mobile breakpoint height to keep proportions on small screens

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ea6c1de9788329abebfc1aee8b6a8d