### PR TITLE
Handle solver timeouts when many optional ingredients are selected

### DIFF
--- a/data/app_translations.json
+++ b/data/app_translations.json
@@ -134,6 +134,7 @@
       "solver_failed": "Bei der Berechnung ist ein Fehler aufgetreten.",
       "solver_search_timeout": "Nach vielen Kombinationen wurden keine Ergebnisse gefunden. Bitte lockere die Einstellungen.",
       "solver_search_partial": "Suche vorzeitig beendet – zeige die besten gefundenen Ergebnisse.",
+      "solver_trimmed_optional": "Zu viele optionale Zutaten ausgewählt. Die Suche wurde auf die {kept} relevantesten von {total} begrenzt.",
       "style_unknown": "—"
     }
   },
@@ -272,6 +273,7 @@
       "solver_failed": "Something went wrong while calculating the recipe.",
       "solver_search_timeout": "Stopped after exploring too many combinations. Try relaxing the filters.",
       "solver_search_partial": "Stopped early after reaching the search limit. Showing the best results found so far.",
+      "solver_trimmed_optional": "Too many optional ingredients selected. Limited the search to the {kept} most relevant out of {total}.",
       "style_unknown": "—"
     }
   }


### PR DESCRIPTION
## Summary
- add an optional trimming fallback when the solver hits the search limit and expose a visit cap override
- skip disallowed optional ingredients during search and report when the list is trimmed
- add translations and regression coverage for the trimming behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f011e51d508329b99304db16bee3bd