### PR TITLE
Allow range slider thumbs to overlap track

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -854,7 +854,7 @@ body[data-theme='dark'] .chip:focus-visible {
   height: 12px;
   border-radius: 999px;
   background: var(--slider-track-gradient);
-  overflow: hidden;
+  overflow: visible;
 }
 
 .range-slider::before {
@@ -863,6 +863,7 @@ body[data-theme='dark'] .chip:focus-visible {
   inset: 0;
   background: var(--slider-track, var(--slider-track-gradient));
   opacity: 0.75;
+  border-radius: inherit;
 }
 
 .range-slider-thumb {


### PR DESCRIPTION
## Summary
- allow range slider thumbs to sit above the track by removing overflow clipping
- keep the track corners rounded by letting the pseudo-element inherit the slider radius

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f0b44fd9448329a7aed9a01e249b05