### PR TITLE
Adjust default slider mode activation

### DIFF
--- a/app.py
+++ b/app.py
@@ -458,9 +458,9 @@ def index():
         constraints = {
             a: SimpleNamespace(
                 band="any",
-                mode="eq",
-                min=default_value,
-                max=default_value,
+                mode="any",
+                min="",
+                max="",
                 value=default_value,
             )
             for a in ATTRS

--- a/static/solver.js
+++ b/static/solver.js
@@ -2041,6 +2041,7 @@ const initSolver = () => {
 
     const handleSliderInput = (handleEl, roleHint) => {
       if (!handleEl) return;
+      const wasNeutralMode = currentMode === 'any';
       const role = roleHint || handleEl.dataset.handleRole || 'eq';
       let value = 0;
       if (sliderController) {
@@ -2048,6 +2049,9 @@ const initSolver = () => {
         value = normalizeValue(key ? sliderController.getValue(key) : 0);
       } else {
         value = normalizeValue(sliderStepToNumber(handleEl.value));
+      }
+      if (wasNeutralMode) {
+        setModeValue('eq');
       }
       if (role === 'ge') {
         storedValues.ge = value;


### PR DESCRIPTION
## Summary
- default attribute sliders to an inactive mode instead of selecting the equals constraint
- automatically activate the equals constraint when a neutral slider is adjusted

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f0b4c25b188329af7eb208830fc24b