### PR TITLE
Improve dark mode beer style dropdown contrast

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -123,8 +123,8 @@ body[data-theme='dark'] {
   --tint-strong: rgba(148, 163, 184, 0.24);
   --tint-border: rgba(15, 23, 42, 0.6);
   --tint-border-strong: rgba(148, 163, 184, 0.32);
-  --form-field-surface: rgba(15, 23, 42, 0.72);
-  --form-field-border: rgba(148, 163, 184, 0.28);
+  --form-field-surface: rgba(9, 14, 26, 0.9);
+  --form-field-border: rgba(148, 163, 184, 0.36);
   --form-field-text: #e2e8f0;
   --chip-surface: rgba(148, 163, 184, 0.14);
   --chip-surface-hover: rgba(148, 163, 184, 0.25);
@@ -2678,8 +2678,10 @@ button {
 }
 
 body[data-theme='dark'] .band-style-picker select {
-  box-shadow: inset 0 1px 1px rgba(15, 23, 42, 0.4);
   background-image: var(--select-arrow-icon);
+  background-color: rgba(9, 14, 26, 0.94);
+  border-color: rgba(148, 163, 184, 0.32);
+  box-shadow: 0 10px 30px -18px rgba(2, 6, 23, 0.85), inset 0 1px 1px rgba(15, 23, 42, 0.5);
 }
 
 body[data-theme='dark'] .band-style-picker select:hover {


### PR DESCRIPTION
## Summary
- darken the beer style picker background color in dark mode for better contrast
- adjust dark theme border and shadow styling to match the new tone

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f0cecc71cc8329ace281e082a56318