### PR TITLE
Ensure required ingredient checkboxes retain locked styling

### DIFF
--- a/static/solver.js
+++ b/static/solver.js
@@ -2794,7 +2794,7 @@ const initSolver = () => {
       }
       const requiredCount = activeMins[ingredientId] || 0;
       if (requiredCount > 0) {
-        row.classList.add('ingredient-locked');
+        row.classList.add('ingredient-locked', 'ingredient-card--locked');
         includeCheckbox.checked = true;
         includeCheckbox.disabled = true;
         includeCheckbox.dataset.userSelected = 'false';
@@ -2810,7 +2810,7 @@ const initSolver = () => {
           badge.textContent = formatRequiredBadge(requiredCount);
         }
       } else {
-        row.classList.remove('ingredient-locked');
+        row.classList.remove('ingredient-locked', 'ingredient-card--locked');
         includeCheckbox.disabled = false;
         const userSelected = includeCheckbox.dataset.userSelected === 'true';
         includeCheckbox.checked = userSelected;


### PR DESCRIPTION
## Summary
- add the ingredient-card--locked class whenever a style marks an ingredient as required so the include toggle keeps its required styling
- remove the locked styling when the ingredient is no longer required to keep the UI consistent

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f1e431c7e083298590c0c3c30affb5