### PR TITLE
Remove calculate button and highlight autosolve results

### DIFF
--- a/static/solver.js
+++ b/static/solver.js
@@ -364,7 +364,6 @@ const initSolver = () => {
 
   const {
     attrCards,
-    submitBtn,
     setAllGreenBtn,
     styleSelect,
     ingredientRows,
@@ -1626,19 +1625,6 @@ const initSolver = () => {
     optionalToggleBtn.dataset.state = allChecked ? 'all' : hasAny ? 'some' : 'none';
   };
 
-  const updateSubmitState = () => {
-    if (!submitBtn) return;
-    const hasConstraint = attrCards.some((card) => {
-      const selectedBand = card.querySelector('input[type="radio"][data-color-radio]:checked');
-      const modeInput = card.querySelector('[data-mode-input]');
-      const bandValue = selectedBand ? selectedBand.value : null;
-      const bandActive = !!bandValue && bandValue !== 'any';
-      const modeActive = modeInput && modeInput.value !== 'any';
-      return bandActive || modeActive;
-    });
-    submitBtn.disabled = !hasConstraint;
-  };
-
   attrCards.forEach((card) => {
     const sliderRoot = card.querySelector('[data-slider]');
     const sliderController = sliderRoot ? createSlider(sliderRoot) : null;
@@ -1858,7 +1844,6 @@ const initSolver = () => {
             simpleSummaryUpdater();
           }
         }
-        updateSubmitState();
       };
 
       if (clearBtn) {
@@ -2383,7 +2368,6 @@ const initSolver = () => {
       syncSliderHandles();
       syncHiddenValues();
       updateSliderDisplay();
-      updateSubmitState();
       syncClearButtonState();
       scheduleAutoSolve();
     };
@@ -2444,7 +2428,6 @@ const initSolver = () => {
       applyCurrentSnapToStoredValues();
       syncHiddenValues();
       updateSliderDisplay();
-      updateSubmitState();
       syncClearButtonState();
       if (colorRadios.some((radio) => radio.checked)) {
         applyColorSelection(null, { focus: false, suppressSolve: true, suppressModeRestore: true });
@@ -2466,7 +2449,6 @@ const initSolver = () => {
       syncSliderHandles();
       syncHiddenValues();
       updateSliderDisplay();
-      updateSubmitState();
       syncClearButtonState();
       scheduleAutoSolve();
     };
@@ -2524,7 +2506,6 @@ const initSolver = () => {
       syncHiddenValues();
       updateSliderDisplay();
       applyColorSelection(null, { focus: false });
-      updateSubmitState();
       syncClearButtonState();
     };
 
@@ -2698,7 +2679,6 @@ const initSolver = () => {
       }
 
       setSliderDisabled(false);
-      updateSubmitState();
       syncClearButtonState();
     };
 
@@ -2789,7 +2769,6 @@ const initSolver = () => {
       if (typeof allGreenWatcher === 'function') {
         allGreenWatcher();
       }
-      updateSubmitState();
       scheduleAutoSolve();
 
       setButtonMode(currentMode === 'green' ? 'any' : 'green');
@@ -3450,7 +3429,6 @@ const initSolver = () => {
     applyStyleRequirements(styleSelect.value);
   }
 
-  updateSubmitState();
   updateOptionalToggleState();
   if (!styleSelect) {
     refreshMixSummary();

--- a/static/styles.css
+++ b/static/styles.css
@@ -2078,21 +2078,37 @@ body[data-theme='dark'] .chip:focus-visible {
   justify-content: center;
 }
 
-.mix-panel__submit {
-  align-self: stretch;
-}
-
 .results-section {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 20px;
 }
 
 .results-header {
+  position: relative;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 16px;
+  gap: 20px;
+  padding: 20px 24px;
+  border-radius: 20px;
+  background: linear-gradient(135deg, var(--accent-muted), rgba(15, 23, 42, 0.82));
+  border: 1px solid var(--results-card-border);
+  box-shadow:
+    0 18px 38px rgba(15, 23, 42, 0.45),
+    0 0 0 1px rgba(148, 163, 184, 0.12);
+  overflow: hidden;
+}
+
+.results-header::before {
+  content: '';
+  position: absolute;
+  inset: auto -40% -60px auto;
+  width: 180px;
+  height: 180px;
+  background: radial-gradient(circle at center, rgba(249, 115, 22, 0.35), transparent 65%);
+  transform: rotate(12deg);
+  pointer-events: none;
 }
 
 .results-heading {
@@ -2103,8 +2119,25 @@ body[data-theme='dark'] .chip:focus-visible {
 
 .results-title {
   margin: 0;
-  font-size: 1rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 1.15rem;
+  letter-spacing: 0.02em;
   color: var(--results-card-title);
+}
+
+.results-title__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 12px;
+  background: rgba(249, 115, 22, 0.18);
+  color: var(--accent-strong);
+  box-shadow: 0 8px 18px rgba(249, 115, 22, 0.28);
+  font-size: 1.2rem;
 }
 
 .results-total-highlight {

--- a/static/ui-state.js
+++ b/static/ui-state.js
@@ -21,7 +21,6 @@ export const initUIState = () => {
 
   const selectors = {
     attrCards,
-    submitBtn: document.querySelector('[data-submit-button]'),
     setAllGreenBtn: document.querySelector('[data-set-all-green]'),
     styleSelect: document.querySelector('select[name="style"]'),
     ingredientRows: Array.from(document.querySelectorAll('[data-ingredient-row]')),

--- a/templates/index.html
+++ b/templates/index.html
@@ -423,11 +423,13 @@
                             </div>
                         </div>
                     </div>
-                    <button class="btn-primary mix-panel__submit" type="submit" data-submit-button{% if not has_active_constraints %} disabled{% endif %}>{{ ui.button_submit }}</button>
                     <section class="results-section" data-results>
                         <div class="results-header" data-results-header>
                             <div class="results-heading">
-                                <h3 class="section-title results-title" data-results-title>{{ ui.section_results }}</h3>
+                                <h3 class="section-title results-title" data-results-title>
+                                    <span class="results-title__icon" aria-hidden="true">⚗️</span>
+                                    {{ ui.section_results }}
+                                </h3>
                                 <p class="hint results-placeholder" data-results-placeholder>{{ ui.results_placeholder }}</p>
                             </div>
                             <div class="results-loading" data-results-loading hidden role="status" aria-live="polite">


### PR DESCRIPTION
## Summary
- remove the manual calculate button now that solving happens automatically
- refresh the results header with an icon-forward highlight that anchors the panel visually
- drop unused submit button handling logic from the client scripts

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f2ad25c1488329aa14ba89312deaf0